### PR TITLE
Change shebang interpreter

### DIFF
--- a/subedit
+++ b/subedit
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 
 #	Copyright 2016-2017 George Savvidis, Odysseas Raftopoulos


### PR DESCRIPTION
I believe that using /bin/bash is more reliable than /usr/bin/bash. For example, in Ubuntu it does not work.