### PR TITLE
Set default return value of 0 for main_function()

### DIFF
--- a/subedit
+++ b/subedit
@@ -5856,6 +5856,8 @@ master_function ()
 	if ! [[ $srtok ]] && ! [[ $subok ]] && ! [[ $subtitleis ]]; then
 		basic_clean_up; (($? != 0)) && return 1
 	fi
+
+	return 0
 }
 
 if [[ $inputfilename ]]; then


### PR DESCRIPTION
This is a small patch that fixes the bug which causes the script (in some cases) to immediately stop after the execution of main_function(), returning other code than 0.

The bug happens because the main function tries to execute its sub tasks, returning the value 1 if any of them goes wrong. However, no default return code was set, so if none of the tasks went wrong or if no other flags but -i \<input file\> were given, the return code shall be whatever was previously stored in $?

This can be fixed with a simple "return 0" at the end of main_function.